### PR TITLE
fix: syntax error with PowerShell 5.1

### DIFF
--- a/src/core/lib/library.ps1
+++ b/src/core/lib/library.ps1
@@ -129,7 +129,8 @@ function anyi_extract_tar_xz ([string]$src, [string]$dst) {
   if (Get-Command 7z.exe -ErrorAction SilentlyContinue) {
     # Windows + 7z
     $temp_tar = [System.IO.Path]::GetTempFileName()
-    7z.exe x -txz "${src}" -so > "${temp_tar}" && 7z.exe x -ttar "${temp_tar}" -o"${dst}"
+    7z.exe x -txz "${src}" -so > "${temp_tar}"
+    7z.exe x -ttar "${temp_tar}" -o"${dst}"
     Remove-Item "${temp_tar}"
   }
   elseif ((Get-Command tar.exe -ErrorAction SilentlyContinue) -and (Get-Command xz.exe -ErrorAction SilentlyContinue)) {

--- a/toolset/bun/install.ps1
+++ b/toolset/bun/install.ps1
@@ -177,7 +177,8 @@ function _any_install_main {
     if (Get-Command 7z.exe -ErrorAction SilentlyContinue) {
       # Windows + 7z
       $temp_tar = [System.IO.Path]::GetTempFileName()
-      7z.exe x -txz "${src}" -so > "${temp_tar}" && 7z.exe x -ttar "${temp_tar}" -o"${dst}"
+      7z.exe x -txz "${src}" -so > "${temp_tar}"
+      7z.exe x -ttar "${temp_tar}" -o"${dst}"
       Remove-Item "${temp_tar}"
     }
     elseif ((Get-Command tar.exe -ErrorAction SilentlyContinue) -and (Get-Command xz.exe -ErrorAction SilentlyContinue)) {

--- a/toolset/node/install.ps1
+++ b/toolset/node/install.ps1
@@ -171,7 +171,8 @@ function _any_install_main {
     if (Get-Command 7z.exe -ErrorAction SilentlyContinue) {
       # Windows + 7z
       $temp_tar = [System.IO.Path]::GetTempFileName()
-      7z.exe x -txz "${src}" -so > "${temp_tar}" && 7z.exe x -ttar "${temp_tar}" -o"${dst}"
+      7z.exe x -txz "${src}" -so > "${temp_tar}"
+      7z.exe x -ttar "${temp_tar}" -o"${dst}"
       Remove-Item "${temp_tar}"
     }
     elseif ((Get-Command tar.exe -ErrorAction SilentlyContinue) -and (Get-Command xz.exe -ErrorAction SilentlyContinue)) {

--- a/toolset/shellcheck/install.ps1
+++ b/toolset/shellcheck/install.ps1
@@ -175,7 +175,8 @@ function _any_install_main {
     if (Get-Command 7z.exe -ErrorAction SilentlyContinue) {
       # Windows + 7z
       $temp_tar = [System.IO.Path]::GetTempFileName()
-      7z.exe x -txz "${src}" -so > "${temp_tar}" && 7z.exe x -ttar "${temp_tar}" -o"${dst}"
+      7z.exe x -txz "${src}" -so > "${temp_tar}"
+      7z.exe x -ttar "${temp_tar}" -o"${dst}"
       Remove-Item "${temp_tar}"
     }
     elseif ((Get-Command tar.exe -ErrorAction SilentlyContinue) -and (Get-Command xz.exe -ErrorAction SilentlyContinue)) {


### PR DESCRIPTION
PowerShell 5.1 is old but still in support because it's a part of Windows 10/11: https://github.com/PowerShell/PowerShell/discussions/16971

So, we should keep supporting PowerShell 5.1 until its EOL.

For now, this tiny invalid syntax causes an error with 5.1 and this commit is fixing it.

## Error

```
iex : At line:178 char:50
+       7z.exe x -txz "${src}" -so > "${temp_tar}" && 7z.exe x -ttar "$ ...
+                                                  ~~
The token '&&' is not a valid statement separator in this version.
At line:1 char:61
+ Get-Content .\toolset\shellcheck\install.ps1 | Out-String | iex
+                                                             ~~~
    + CategoryInfo          : ParserError: (:) [Invoke-Expression], ParseException
    + FullyQualifiedErrorId : InvalidEndOfLine,Microsoft.PowerShell.Commands.InvokeExpressionCommand
```

## Follow up

- [ ] Add tests with PowerShell 5.1
